### PR TITLE
33 issues with plotting current routing paths

### DIFF
--- a/controller/controller/cli.py
+++ b/controller/controller/cli.py
@@ -109,6 +109,10 @@ def main(command, verbose, version, config, plot, daemon):
     interval = ServerConfig.from_json_file(config).routing.time
     timeout = time.time()+int(interval)
     while True:
+        # look for incoming request from the serial interface
+        if not serial_output_queue.empty():
+            data = serial_output_queue.get()
+            handle_serial_packet(data, ack_queue)
         # Run the routing protocol?
         if(time.time() > timeout):
             # put a job
@@ -126,7 +130,3 @@ def main(command, verbose, version, config, plot, daemon):
             for node in nodes:
                 nc_input_queue.put(node)
             # nc_input_queue.put(path)
-        # look for incoming request from the serial interface
-        if not serial_output_queue.empty():
-            data = serial_output_queue.get()
-            handle_serial_packet(data, ack_queue)

--- a/controller/controller/database/database.py
+++ b/controller/controller/database/database.py
@@ -67,8 +67,8 @@ class Database(object):
         return Database.DATABASE[collection].update_one(filter, update, upsert=upsert, array_filters=arrayFilters)
 
     @staticmethod
-    def aggregate(collection):
-        return Database.DATABASE[collection].aggregate([{"$unwind": "$routes"}])
+    def aggregate(collection, pipeline):
+        return Database.DATABASE[collection].aggregate(pipeline)
 
     @staticmethod
     def find(collection, query):
@@ -84,8 +84,8 @@ class Database(object):
             print(document)
 
     @staticmethod
-    def find_one(collection, query):
-        return Database.DATABASE[collection].find_one(query)
+    def find_one(collection, query, sort=None):
+        return Database.DATABASE[collection].find_one(query, sort=sort)
 
     @staticmethod
     def delete_collection(collection):

--- a/controller/controller/forwarding_table/forwarding_table.py
+++ b/controller/controller/forwarding_table/forwarding_table.py
@@ -43,7 +43,7 @@ class FWD_TABLE(object):
 
     @staticmethod
     def fwd_get_graph(source, target, attribute, deployed):
-        db = Database.find_one(FORWARDING_TABLE, {})
+        db = Database.find_one(FORWARDING_TABLE, {},None)
         df = pd.DataFrame()
         Graph = nx.Graph()
         if(db is None):
@@ -80,7 +80,7 @@ class FWD_TABLE(object):
                 {"dst": dst},
                 {"via": via},
         ]}
-        db = Database.find_one(FORWARDING_TABLE, query)
+        db = Database.find_one(FORWARDING_TABLE, query,None)
         return db
 
     @staticmethod

--- a/controller/controller/network_config/network_config.py
+++ b/controller/controller/network_config/network_config.py
@@ -26,7 +26,7 @@ def routes_to_deploy(node, routes):
             {"routes.dst": route["dst"]},
             {"routes.via": route["via"]},
         ]}
-        db = Database.find_one("nodes", query)
+        db = Database.find_one("nodes", query,None)
         print("printing db for route")
         print(route)
         print("printing db for route2")

--- a/controller/controller/routing/routing.py
+++ b/controller/controller/routing/routing.py
@@ -46,7 +46,7 @@ def save_routes(rts):
 
 
 def load_data(collection, source, target, attribute):
-    db = Database.find_one(collection, {})
+    db = Database.find_one(collection, {}, None)
     df = pd.DataFrame()
     Graph = nx.Graph()
     if(db is None):
@@ -101,6 +101,8 @@ class Routing(mp.Process):
     def dijkstra(self, G):
         # We want to compute the SP from controller to all nodes
         length, path = nx.single_source_dijkstra(G, "1.0", None, None, "rssi")
+        print("dijkstra path")
+        print(path)
         # Let's put the path in the queue
         self.output_queue.put(path)
 

--- a/controller/controller/serial/serial_packet_dissector.py
+++ b/controller/controller/serial/serial_packet_dissector.py
@@ -88,7 +88,7 @@ def process_data_packet(data):
             Database.insert("nodes", node)
         else:
             # look for last seq number for that node
-            db = Database.find_one("nodes", {"data.src": src})
+            db = Database.find_one("nodes", {"data.src": src},None)
             if(db is not None):
                 df = pd.DataFrame(db['data'])
                 df = df.tail(1)
@@ -312,7 +312,7 @@ def insert_links(data):
         'rssi': data['rssi'],
     }
     # load the collection to pandas frame
-    db = Database.find_one("links", {})
+    db = Database.find_one("links", {},None)
     if(db is None):
         Database.insert("links", links)
     else:


### PR DESCRIPTION
We now plot routes that are already deployed in the network. We use the "historical-routes" collection to get the current routes and we check if they are already deployed in the "fwd_table" collection.